### PR TITLE
Add leading zero to sub minute duration formatting

### DIFF
--- a/Nuage/Helpers.swift
+++ b/Nuage/Helpers.swift
@@ -43,12 +43,14 @@ private var durationFormatter: DateComponentsFormatter = {
     let formatter = DateComponentsFormatter()
     formatter.unitsStyle = .positional
     formatter.allowedUnits = [.hour, .minute, .second]
+    formatter.zeroFormattingBehavior = .pad
     
     return formatter
 }()
 
 func format<Time: BinaryFloatingPoint>(time: Time) -> String {
-    return durationFormatter.string(from: TimeInterval(time)) ?? "0"
+    return durationFormatter.string(from: TimeInterval(time))?
+        .replacingOccurrences(of: #"^00[:.]0?|^0"#, with: "", options: .regularExpression) ?? "0:00"
 }
 
 extension AnyCancellable {


### PR DESCRIPTION
Currently values below 60 are formatted without a leading minute unit. This PR proposes that the minute counter should not collapse but should display "0", in turn the seconds counter must always be of double digits.

Formatting of values equal to or larger than 60 remains unchanged.

| seconds | previous formatting | current formatting |
|---|---|---|
| 0 | 0 | 0:00 |
| 10 | 10 | 0:10 |
| 60 | 1:00 | 1:00 |
| 3600 | 1:00:00 | 1:00:00 |

This change reflects the behaviour of SoundCloud