### PR TITLE
Fix Sign-in for SoundCloud account

### DIFF
--- a/Nuage/Views/WebView.swift
+++ b/Nuage/Views/WebView.swift
@@ -80,9 +80,7 @@ class WebViewCoordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         if keyPath == "URL" {
             let webView = object! as! WKWebView
           
-            if (webView != nil) {
-                webView.reload()
-            
+            if (webView != nil) {            
                 self.scanCookiesForAccessToken(webView: webView)
             }
         }


### PR DESCRIPTION
Apparently, when signing into SoundCloud via https://soundcloud.com/signin it's not re-requesting the page from the server again, which means the cookies don't get sent from the server-side since the login logic is all handled client-side. The user gets is signed in the WebView, but doesn't have the needed `oauth_token` cookie Nuage is looking for.

When reloading the page it properly re-requests the page from the server-side which then also properly sets all the cookies. But of course, manually reloading the page is not very user-friendly.

Therefore this pull request updates the WebView logic to listen for changes to the `WebView.url` property and scans the cookies again in such instances. I assume it didn't work before because it ran the cookie-check too early in the chain of events, while the "after-sign-in page" wasn't fully loaded yet.

With this observer it receives the needed `oauth_token` cookie in-time and can continue as intended.

Resolves #28 