### PR TITLE
Add Discover tab; fix high-CPU/stuck-nav bugs from #50

### DIFF
--- a/Nuage.xcodeproj/project.pbxproj
+++ b/Nuage.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		4988D84625A1C62E0092BAFF /* UserDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4988D84525A1C62E0092BAFF /* UserDetail.swift */; };
 		498C72F32A790AF300AA1AAF /* StatsStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498C72F22A790AF300AA1AAF /* StatsStack.swift */; };
 		4998E12125CADC8300EB986F /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4998E12025CADC8300EB986F /* Artwork.swift */; };
+		D15C0BE100000001000000DC /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15C0BE200000001000000DC /* DiscoverView.swift */; };
 		4999998D25B0886700F42D9B /* WaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999998C25B0886700F42D9B /* WaveformView.swift */; };
 		49A89C032A5EA1B70019648F /* Likes.json in Resources */ = {isa = PBXBuildFile; fileRef = 49A89C022A5EA12D0019648F /* Likes.json */; };
 		49A99D7A2A7454EE001B8BCB /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A99D792A7454EE001B8BCB /* Navigation.swift */; };
@@ -85,6 +86,7 @@
 		4988D84525A1C62E0092BAFF /* UserDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetail.swift; sourceTree = "<group>"; };
 		498C72F22A790AF300AA1AAF /* StatsStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStack.swift; sourceTree = "<group>"; };
 		4998E12025CADC8300EB986F /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
+		D15C0BE200000001000000DC /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
 		4999998C25B0886700F42D9B /* WaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformView.swift; sourceTree = "<group>"; };
 		49A89C022A5EA12D0019648F /* Likes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Likes.json; sourceTree = "<group>"; };
 		49A99D792A7454EE001B8BCB /* Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				4969F41C257CFB100048E29B /* UserGrid.swift */,
 				49E6259C25BE1E7E005BEF8C /* WebView.swift */,
 				4998E12025CADC8300EB986F /* Artwork.swift */,
+				D15C0BE200000001000000DC /* DiscoverView.swift */,
 				493AB3542A6E668C00E20656 /* FeedbackStack.swift */,
 				498C72F22A790AF300AA1AAF /* StatsStack.swift */,
 				49FEEBDE2A5B56C9002C8865 /* TouchBar.swift */,
@@ -351,6 +354,7 @@
 				4969F3C9257CFA7F0048E29B /* NuageApp.swift in Sources */,
 				4969F436257CFB100048E29B /* MainView.swift in Sources */,
 				4998E12125CADC8300EB986F /* Artwork.swift in Sources */,
+				D15C0BE100000001000000DC /* DiscoverView.swift in Sources */,
 				4969F428257CFB100048E29B /* Helpers.swift in Sources */,
 				49FA14C62589693E00CEF925 /* InfiniteList.swift in Sources */,
 				490857292A718FFF002D4FD0 /* PostRow.swift in Sources */,

--- a/Nuage/Navigation.swift
+++ b/Nuage/Navigation.swift
@@ -11,15 +11,17 @@ private let userPlaylistSeparator = "@@USERPLAYLIST@@"
 private let systemPlaylistSeparator = "@@SYSTEMPLAYLIST@@"
 
 enum SidebarItem: RawRepresentable {
+    case discover
     case stream
     case likes
     case history
     case following
     case userPlaylist(String, String)
     case systemPlaylist(String, String)
-    
+
     init?(rawValue: String) {
         switch rawValue {
+        case "discover": self = .discover
         case "stream": self = .stream
         case "likes": self = .likes
         case "history": self = .history
@@ -42,6 +44,7 @@ enum SidebarItem: RawRepresentable {
     
     var rawValue: String {
         switch self {
+        case .discover: return "discover"
         case .stream: return "stream"
         case .likes: return "likes"
         case .history: return "history"
@@ -61,6 +64,7 @@ enum SidebarItem: RawRepresentable {
     
     var imageName: String? {
         switch self {
+        case .discover: return "sparkles"
         case .stream: return "bolt.horizontal.fill"
         case .likes: return "heart.fill"
         case .history: return "clock.fill"

--- a/Nuage/Views/DiscoverView.swift
+++ b/Nuage/Views/DiscoverView.swift
@@ -1,0 +1,161 @@
+//
+//  DiscoverView.swift
+//  Nuage
+//
+
+import SwiftUI
+import Combine
+import SoundCloud
+
+struct DiscoverView: View {
+
+    @State private var selections = [Selection]()
+    @State private var didLoad = false
+    @State private var subscriptions = Set<AnyCancellable>()
+
+    var body: some View {
+        Group {
+            if selections.isEmpty && !didLoad {
+                ProgressView().progressViewStyle(.circular)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 24) {
+                        ForEach(selections) { selection in
+                            SelectionRow(selection: selection)
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .onAppear(perform: load)
+    }
+
+    private func load() {
+        guard !didLoad else { return }
+        SoundCloud.shared.get(.mixedSelections(), limit: 10)
+            .map { $0.collection }
+            .replaceError(with: [])
+            .receive(on: RunLoop.main)
+            .sink { value in
+                selections = value
+                didLoad = true
+            }
+            .store(in: &subscriptions)
+    }
+
+}
+
+private struct SelectionRow: View {
+
+    var selection: Selection
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(selection.title)
+                .font(.title2)
+                .bold()
+            if let description = selection.description, !description.isEmpty {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: 16) {
+                    ForEach(selection.items.uniqued(), id: \.uniqueID) { item in
+                        switch item {
+                        case .playlist(let playlist): PlaylistCard(playlist: playlist)
+                        case .user(let user): UserCard(user: user)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+}
+
+private let cardWidth: CGFloat = 160
+
+private struct PlaylistCard: View {
+
+    var playlist: AnyPlaylist
+
+    var body: some View {
+        NavigationLink(value: playlist) {
+            VStack(alignment: .leading, spacing: 6) {
+                RemoteImage(url: playlist.artworkURL, cornerRadius: 6)
+                    .frame(width: cardWidth, height: cardWidth)
+                Text(playlist.title)
+                    .font(.subheadline)
+                    .bold()
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                if playlist.userPlaylist != nil {
+                    Text(playlist.user.username)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(width: cardWidth, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+    }
+
+}
+
+private struct UserCard: View {
+
+    var user: User
+
+    var body: some View {
+        NavigationLink(value: user) {
+            VStack(alignment: .leading, spacing: 6) {
+                RemoteImage(url: user.avatarURL, cornerRadius: cardWidth / 2)
+                    .frame(width: cardWidth, height: cardWidth)
+                Text(user.username)
+                    .font(.subheadline)
+                    .bold()
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                if let followers = user.followerCount {
+                    HStack(spacing: 2) {
+                        Text(String(followers))
+                        Image(systemName: "person.2.fill")
+                    }
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+            }
+            .frame(width: cardWidth, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+    }
+
+}
+
+private extension AnyItem {
+
+    // `id` collapses User and Playlist IDs into the same numeric namespace.
+    // Prefix by kind so the dedupe and ForEach identity stay correct.
+    var uniqueID: String {
+        switch self {
+        case .user(let user): return "user:\(user.id)"
+        case .playlist(let playlist): return "playlist:\(playlist.id)"
+        }
+    }
+
+}
+
+private extension Array where Element == AnyItem {
+
+    // The endpoint can repeat the same item in a row (e.g. "Recently Played"
+    // returns the same mix once per play). Keep the first occurrence.
+    func uniqued() -> [AnyItem] {
+        var seen = Set<String>()
+        return filter { seen.insert($0.uniqueID).inserted }
+    }
+
+}

--- a/Nuage/Views/InfiniteView/PageView.swift
+++ b/Nuage/Views/InfiniteView/PageView.swift
@@ -64,15 +64,10 @@ struct PageView<Element: Decodable&Identifiable, ContentView: View>: View {
     }
     
     private func getNextPage() {
-        guard subscriptions[elements.count] == nil else { return }
+        guard subscriptions[elements.count] == nil,
+              let lastPage = pages?.last else { return }
 
-        let currentPagePublisher = (pages ?? []).publisher
-            .last()
-            .mapError { $0 as Error }
-
-        publisher.merge(with: currentPagePublisher)
-            .first()
-            .flatMap { SoundCloud.shared.get(next: $0) }
+        SoundCloud.shared.get(next: lastPage)
             .receive(on: RunLoop.main)
             .sink(receiveCompletion: { _ in }, receiveValue: { page in
                 pages?.append(page)

--- a/Nuage/Views/Lists/TrackList.swift
+++ b/Nuage/Views/Lists/TrackList.swift
@@ -48,7 +48,19 @@ extension TrackList where Element == Track {
         }
         self.init(for: ids, page: page)
     }
-    
+
+    init(playlist: AnyPlaylist) {
+        if let ids = playlist.trackIDs, !ids.isEmpty {
+            let arr = Just(ids).setFailureType(to: Error.self).eraseToAnyPublisher()
+            self.init(for: arr) { SoundCloud.shared.get(.tracks($0)) }
+            return
+        }
+        switch playlist {
+        case .user(let p): self.init(request: .userPlaylist(p.id))
+        case .system(let p): self.init(request: .systemPlaylist(p.urn))
+        }
+    }
+
 }
 
 extension TrackList where Element == Like<Track> {

--- a/Nuage/Views/MainView.swift
+++ b/Nuage/Views/MainView.swift
@@ -41,6 +41,10 @@ struct MainView: View {
                         .navigationDestinationWithPlaybackContext(for: Track.self) { TrackDetail(track: $0) }
                         .navigationDestination(for: User.self) { UserDetail(user: $0) }
                         .navigationDestination(for: URL.self) { URLDetail(url: $0) }
+                        .navigationDestination(for: AnyPlaylist.self) { playlist in
+                            TrackList(playlist: playlist)
+                                .navigationTitle(playlist.title)
+                        }
                         .navigationDestination(for: Station.self) { station in
                             switch station {
                             case .track(let track): TrackList(request: .trackStation(basedOn: track))
@@ -83,6 +87,7 @@ struct MainView: View {
     
     @ViewBuilder private func sidebar() -> some View {
         List(selection: $sidebarSelection) {
+            sidebarMenu(for: .discover)
             sidebarMenu(for: .stream)
             sidebarMenu(for: .likes)
             sidebarMenu(for: .history)
@@ -122,6 +127,8 @@ struct MainView: View {
     @ViewBuilder private func root(for item: SidebarItem) -> some View {
         Group {
             switch item {
+            case .discover:
+                DiscoverView()
             case .stream:
                 let stream = SoundCloud.shared.get(.stream(), count: 50)
                 PostList(for: stream)

--- a/Nuage/Views/MainView.swift
+++ b/Nuage/Views/MainView.swift
@@ -67,6 +67,10 @@ struct MainView: View {
         .toolbarRole(.editor)
         .toolbar(content: toolbar)
         .touchBar { TouchBar() }
+        .onChange(of: sidebarSelection) { _ in
+            navigationPath = NavigationPath()
+            blockingNavigationPath = nil
+        }
         .onOpenURL { url in
             guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return }
             


### PR DESCRIPTION
Adds a Discover tab and fixes the two bugs reported in #50 (high CPU on Following + can't switch tabs without back button). Depends on lbrndnr/SoundCloud#5 for the new endpoint and artwork fallback.

## What's in here

**Fix wasteful refetch in `PageView.getNextPage`** (`4f9342d`): when loading the next page, the old code did `publisher.merge(with: currentPagePublisher).first()` to get the current page. That re-subscribed to the *original* publisher every call. For cumulative-count publishers (e.g. `SoundCloud.shared.get(.followings(of:), count: 50)` used by the Following tab), this re-fired the whole 50-item pagination on every scroll trigger, dispatching up to 50 URLSession requests and JSON decodes per call. `.first()` cancels after one emission, but the requests are already in flight. The fix uses `pages.last` directly (which is already in `@State`), so each `getNextPage` does exactly one network request. This is what's behind the high CPU report in #50 and matches the "clicking artist #50" symptom (the deeper you scroll, the more reappear events trigger).

**Reset navigation stack when sidebar selection changes** (`b5a9e98`): also from #50, the "cannot switch tabs without clicking the back button first" part. Clicking a sidebar item updated `sidebarSelection`, but the `NavigationStack`'s path retained whatever detail was pushed (track / user / playlist), so the new root rendered underneath the old detail. `onChange(of: sidebarSelection)` now clears `navigationPath` (and `blockingNavigationPath` so the player's "open now playing" still works) so the new section's root is what you see.

**Add Discover tab** (`8a68d3c`): new sidebar entry that fetches `GET /mixed-selections` once on appear and renders a vertical list of horizontal-scroll playlist rails ("More of what you like", "Recently Played", "Mixed for you", etc.). Tapping a card opens the playlist via a new `navigationDestination(for: AnyPlaylist.self)`. To match the web client's behavior, when a `SystemPlaylist` already has its track stubs (which mixed-selections always populates), `TrackList(playlist:)` uses them directly to batch-resolve via `GET /tracks?ids=...`, avoiding a redundant `/system-playlists/<urn>` round-trip. The `SoundCloud` submodule is bumped to pick up the new endpoint.

## Why this layout

The two bug fixes are independent of Discover and useful on their own. Happy to split into separate PRs if you'd prefer; let me know.

Closes #50.