### PR TITLE
Abbreviate large play, like and follower counts

### DIFF
--- a/Nuage/Helpers.swift
+++ b/Nuage/Helpers.swift
@@ -35,6 +35,29 @@ func format<Time: BinaryFloatingPoint>(time: Time) -> String {
 //    return text
 }
 
+private var countFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.maximumFractionDigits = 1
+    formatter.usesGroupingSeparator = false
+
+    return formatter
+}()
+
+func format(count: Int) -> String {
+    if count < 1_000 { return String(count) }
+
+    let value = Double(count)
+    let (scaled, suffix): (Double, String)
+    switch value {
+    case 1_000_000_000...: (scaled, suffix) = (value / 1_000_000_000, "B")
+    case 1_000_000...:     (scaled, suffix) = (value / 1_000_000, "M")
+    default:               (scaled, suffix) = (value / 1_000, "K")
+    }
+
+    return (countFormatter.string(from: NSNumber(value: scaled)) ?? String(count)) + suffix
+}
+
 extension AnyCancellable {
     
     func store<T: Hashable>(in dictionary: inout Dictionary<T, AnyCancellable>, key: T) {

--- a/Nuage/Views/Details/UserDetail.swift
+++ b/Nuage/Views/Details/UserDetail.swift
@@ -29,8 +29,8 @@ struct UserDetail: View {
                         .lineLimit(1)
                     
                     HStack {
-                        Text("\(currentUser.followerCount ?? 0) Followers")
-                        Text("\(currentUser.followingCount ?? 0) Following")
+                        Text("\(format(count: currentUser.followerCount ?? 0)) Followers")
+                        Text("\(format(count: currentUser.followingCount ?? 0)) Following")
                     }
                     
                     if let description = currentUser.description {

--- a/Nuage/Views/DiscoverView.swift
+++ b/Nuage/Views/DiscoverView.swift
@@ -122,7 +122,7 @@ private struct UserCard: View {
                     .multilineTextAlignment(.leading)
                 if let followers = user.followerCount {
                     HStack(spacing: 2) {
-                        Text(String(followers))
+                        Text(format(count: followers))
                         Image(systemName: "person.2.fill")
                     }
                     .font(.caption)

--- a/Nuage/Views/StatsStack.swift
+++ b/Nuage/Views/StatsStack.swift
@@ -15,17 +15,17 @@ struct StatsStack: View {
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: "play.fill")
-            Text(String(track.playbackCount))
+            Text(format(count: track.playbackCount))
             
             Spacer().frame(width: 2)
             
             Image(systemName: "heart.fill")
-            Text(String(track.likeCount))
+            Text(format(count: track.likeCount))
             
             Spacer().frame(width: 2)
             
             Image(systemName: "arrow.triangle.2.circlepath")
-            Text(String(track.repostCount))
+            Text(format(count: track.repostCount))
         }
     }
     

--- a/Nuage/Views/UserGrid.swift
+++ b/Nuage/Views/UserGrid.swift
@@ -57,13 +57,13 @@ struct UserItem: View {
                 .lineLimit(1)
             
             HStack(spacing: 2) {
-                Text(String(user.followerCount ?? 0))
+                Text(format(count: user.followerCount ?? 0))
                 Image(systemName: "person.2.fill")
                 
                 Spacer()
                     .frame(width: 8)
                 
-                Text(String(user.trackCount ?? 0))
+                Text(format(count: user.trackCount ?? 0))
                 Image(systemName: "waveform")
             }
             .foregroundColor(.secondary)


### PR DESCRIPTION
Raw counts were rendered with String(...), so popular tracks and users showed unwieldy numbers like 47184719. Add a shared format(count:) helper in Helpers.swift, alongside the existing format(time:), that abbreviates counts (for example 1.4B, 12.3K) and route every statistic number through it: track plays/likes/reposts, user follower/following/track counts.

Small change but something I missed when using it :) 