### PR TITLE
Fix: Auto-Skip non-playable songs

### DIFF
--- a/Nuage.xcodeproj/project.pbxproj
+++ b/Nuage.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		4988D84625A1C62E0092BAFF /* UserDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4988D84525A1C62E0092BAFF /* UserDetail.swift */; };
 		498C72F32A790AF300AA1AAF /* StatsStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498C72F22A790AF300AA1AAF /* StatsStack.swift */; };
 		4998E12125CADC8300EB986F /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4998E12025CADC8300EB986F /* Artwork.swift */; };
-		D15C0BE100000001000000DC /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15C0BE200000001000000DC /* DiscoverView.swift */; };
 		4999998D25B0886700F42D9B /* WaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999998C25B0886700F42D9B /* WaveformView.swift */; };
 		49A89C032A5EA1B70019648F /* Likes.json in Resources */ = {isa = PBXBuildFile; fileRef = 49A89C022A5EA12D0019648F /* Likes.json */; };
 		49A99D7A2A7454EE001B8BCB /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A99D792A7454EE001B8BCB /* Navigation.swift */; };
@@ -50,6 +49,8 @@
 		49FA14BB2589635800CEF925 /* ArrayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FA14BA2589635800CEF925 /* ArrayView.swift */; };
 		49FA14C62589693E00CEF925 /* InfiniteList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FA14C52589693E00CEF925 /* InfiniteList.swift */; };
 		49FEEBDF2A5B56C9002C8865 /* TouchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FEEBDE2A5B56C9002C8865 /* TouchBar.swift */; };
+		7C7EF3C73011578F0019A005 /* PreloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7EF3C63011578F0019A005 /* PreloadManager.swift */; };
+		D15C0BE100000001000000DC /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15C0BE200000001000000DC /* DiscoverView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -86,7 +87,6 @@
 		4988D84525A1C62E0092BAFF /* UserDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetail.swift; sourceTree = "<group>"; };
 		498C72F22A790AF300AA1AAF /* StatsStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStack.swift; sourceTree = "<group>"; };
 		4998E12025CADC8300EB986F /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
-		D15C0BE200000001000000DC /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
 		4999998C25B0886700F42D9B /* WaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformView.swift; sourceTree = "<group>"; };
 		49A89C022A5EA12D0019648F /* Likes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Likes.json; sourceTree = "<group>"; };
 		49A99D792A7454EE001B8BCB /* Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
@@ -96,6 +96,8 @@
 		49FA14BA2589635800CEF925 /* ArrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayView.swift; sourceTree = "<group>"; };
 		49FA14C52589693E00CEF925 /* InfiniteList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteList.swift; sourceTree = "<group>"; };
 		49FEEBDE2A5B56C9002C8865 /* TouchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBar.swift; sourceTree = "<group>"; };
+		7C7EF3C63011578F0019A005 /* PreloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadManager.swift; sourceTree = "<group>"; };
+		D15C0BE200000001000000DC /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +203,7 @@
 		4969F40D257CFB100048E29B /* Audio */ = {
 			isa = PBXGroup;
 			children = (
+				7C7EF3C63011578F0019A005 /* PreloadManager.swift */,
 				4969F40E257CFB100048E29B /* Stream.swift */,
 				4969F40F257CFB100048E29B /* StreamPlayer.swift */,
 			);
@@ -355,6 +358,7 @@
 				4969F436257CFB100048E29B /* MainView.swift in Sources */,
 				4998E12125CADC8300EB986F /* Artwork.swift in Sources */,
 				D15C0BE100000001000000DC /* DiscoverView.swift in Sources */,
+				7C7EF3C73011578F0019A005 /* PreloadManager.swift in Sources */,
 				4969F428257CFB100048E29B /* Helpers.swift in Sources */,
 				49FA14C62589693E00CEF925 /* InfiniteList.swift in Sources */,
 				490857292A718FFF002D4FD0 /* PostRow.swift in Sources */,

--- a/Nuage/Audio/PreloadManager.swift
+++ b/Nuage/Audio/PreloadManager.swift
@@ -1,0 +1,109 @@
+//
+//  PreloadManager.swift
+//  Nuage
+//
+//  Created on 22.07.26.
+//
+
+import Foundation
+import AVFoundation
+import Combine
+import SoundCloud
+
+class PreloadManager {
+    
+    private let lookahead = 15
+    private let timeout: Int = 10
+    
+    private var cachedAssets = [String: AVURLAsset]()
+    private(set) var unplayableTracks = Set<String>()
+    
+    private var preloadSubscriptions = [String: AnyCancellable]()
+    
+    // MARK: - Preloading
+    
+    func preload(queue: [Track], queueOrder: [Int], from startIndex: Int) {
+        guard startIndex < queueOrder.count else { return }
+        
+        let endIndex = min(startIndex + lookahead, queueOrder.count)
+        guard endIndex > startIndex else { return }
+        
+        let upcomingIndices = (startIndex..<endIndex)
+        let upcomingTracks = upcomingIndices.map { queue[queueOrder[$0]] }
+        
+        // Cancel preloads for tracks no longer in the lookahead window
+        let upcomingIDs = Set(upcomingTracks.map { $0.id })
+        for id in preloadSubscriptions.keys where !upcomingIDs.contains(id) {
+            preloadSubscriptions[id]?.cancel()
+            preloadSubscriptions.removeValue(forKey: id)
+        }
+        
+        for track in upcomingTracks {
+            guard !unplayableTracks.contains(track.id),
+                  cachedAssets[track.id] == nil,
+                  preloadSubscriptions[track.id] == nil else { continue }
+            
+            let subscription = track.prepare()
+                .timeout(.seconds(timeout), scheduler: DispatchQueue.main)
+                .sink(receiveCompletion: { [weak self] completion in
+                    guard let self = self else { return }
+                    if case .failure = completion {
+                        self.unplayableTracks.insert(track.id)
+                    }
+                    self.preloadSubscriptions.removeValue(forKey: track.id)
+                }, receiveValue: { [weak self] asset in
+                    guard let self = self else { return }
+                    // Validate the asset is playable
+                    asset.loadValuesAsynchronously(forKeys: ["playable"]) {
+                        var error: NSError?
+                        let status = asset.statusOfValue(forKey: "playable", error: &error)
+                        DispatchQueue.main.async {
+                            if status == .loaded && asset.isPlayable {
+                                self.cachedAssets[track.id] = asset
+                            } else {
+                                self.unplayableTracks.insert(track.id)
+                            }
+                        }
+                    }
+                })
+            
+            preloadSubscriptions[track.id] = subscription
+        }
+    }
+    
+    // MARK: - Access
+    
+    func asset(for track: Track) -> AVURLAsset? {
+        return cachedAssets[track.id]
+    }
+    
+    func isUnplayable(_ track: Track) -> Bool {
+        return unplayableTracks.contains(track.id)
+    }
+    
+    func markUnplayable(_ track: Track) {
+        unplayableTracks.insert(track.id)
+    }
+    
+    // MARK: - Cleanup
+    
+    func evict(before index: Int, queue: [Track], queueOrder: [Int]) {
+        guard index > 0 else { return }
+        let pastIndices = (0..<index)
+        let pastIDs = Set(pastIndices.map { queue[queueOrder[$0]].id })
+        
+        for id in pastIDs {
+            cachedAssets.removeValue(forKey: id)
+        }
+    }
+    
+    func reset() {
+        for (_, sub) in preloadSubscriptions {
+            sub.cancel()
+        }
+        preloadSubscriptions.removeAll()
+        cachedAssets.removeAll()
+        unplayableTracks.removeAll()
+    }
+    
+}

--- a/Nuage/Audio/PreloadManager.swift
+++ b/Nuage/Audio/PreloadManager.swift
@@ -53,12 +53,13 @@ class PreloadManager {
                     self.preloadSubscriptions.removeValue(forKey: track.id)
                 }, receiveValue: { [weak self] asset in
                     guard let self = self else { return }
-                    // Validate the asset is playable
-                    asset.loadValuesAsynchronously(forKeys: ["playable"]) {
+                    // Validate the asset is actually loadable
+                    asset.loadValuesAsynchronously(forKeys: ["playable", "tracks"]) {
                         var error: NSError?
-                        let status = asset.statusOfValue(forKey: "playable", error: &error)
+                        let playableStatus = asset.statusOfValue(forKey: "playable", error: &error)
+                        let tracksStatus = asset.statusOfValue(forKey: "tracks", error: &error)
                         DispatchQueue.main.async {
-                            if status == .loaded && asset.isPlayable {
+                            if playableStatus == .loaded && tracksStatus == .loaded && asset.isPlayable {
                                 self.cachedAssets[track.id] = asset
                             } else {
                                 self.unplayableTracks.insert(track.id)

--- a/Nuage/Audio/PreloadManager.swift
+++ b/Nuage/Audio/PreloadManager.swift
@@ -13,6 +13,7 @@ import SoundCloud
 class PreloadManager {
     
     private let lookahead = 15
+    private let lookbehind = 5
     private let timeout: Int = 10
     
     private var cachedAssets = [String: AVURLAsset]()
@@ -31,14 +32,21 @@ class PreloadManager {
         let upcomingIndices = (startIndex..<endIndex)
         let upcomingTracks = upcomingIndices.map { queue[queueOrder[$0]] }
         
-        // Cancel preloads for tracks no longer in the lookahead window
-        let upcomingIDs = Set(upcomingTracks.map { $0.id })
-        for id in preloadSubscriptions.keys where !upcomingIDs.contains(id) {
-            preloadSubscriptions[id]?.cancel()
-            preloadSubscriptions.removeValue(forKey: id)
-        }
+        preloadTracks(upcomingTracks)
+    }
+    
+    func preloadBackward(queue: [Track], queueOrder: [Int], from currentIndex: Int) {
+        guard currentIndex > 0 else { return }
         
-        for track in upcomingTracks {
+        let startIndex = max(currentIndex - lookbehind, 0)
+        let behindIndices = (startIndex..<currentIndex)
+        let behindTracks = behindIndices.map { queue[queueOrder[$0]] }
+        
+        preloadTracks(behindTracks)
+    }
+    
+    private func preloadTracks(_ tracks: [Track]) {
+        for track in tracks {
             guard !unplayableTracks.contains(track.id),
                   cachedAssets[track.id] == nil,
                   preloadSubscriptions[track.id] == nil else { continue }
@@ -89,8 +97,9 @@ class PreloadManager {
     // MARK: - Cleanup
     
     func evict(before index: Int, queue: [Track], queueOrder: [Int]) {
-        guard index > 0 else { return }
-        let pastIndices = (0..<index)
+        guard index > lookbehind else { return }
+        let evictEnd = index - lookbehind
+        let pastIndices = (0..<evictEnd)
         let pastIDs = Set(pastIndices.map { queue[queueOrder[$0]].id })
         
         for id in pastIDs {

--- a/Nuage/Audio/StreamPlayer.swift
+++ b/Nuage/Audio/StreamPlayer.swift
@@ -27,6 +27,8 @@ class StreamPlayer: ObservableObject {
     private var subscriptions = Set<AnyCancellable>()
     
     private var player: AVPlayer
+    private let preloadManager = PreloadManager()
+    
     private(set) var queue = [Track]() {
         didSet {
             reloadQueueOrder()
@@ -139,31 +141,90 @@ class StreamPlayer: ObservableObject {
             player.play()
         }
         else {
+            // Skip tracks known to be unplayable
+            if preloadManager.isUnplayable(newStream) {
+                skipToNextPlayable(from: idx)
+                return
+            }
+            
             self.currentStreamIndex = idx
             self.shouldSeek = false
             self.progress = 0
             self.shouldSeek = true
             
             let track = currentStream!
-            track.prepare()
-                .receive(on: RunLoop.main)
-                .sink(receiveCompletion: { completion in
-                    if case let .failure(error) = completion  {
-                        print("Failed to stream track: \(error)")
-                    }
-                }, receiveValue: { [weak self] asset in
-                    guard let self = self else { return }
-                    
-                    let item = AVPlayerItem(asset: asset)
-                    
-                    self.player.replaceCurrentItem(with: item)
-                    self.player.play()
-                    
-                    NotificationCenter.default.addObserver(self, selector: #selector(self.advanceForward), name: Notification.Name.AVPlayerItemDidPlayToEndTime, object: item)
-                    
-                    self.updateNowPlayingInfo()
-                }).store(in: &subscriptions)
+            
+            // Use preloaded asset if available
+            if let asset = preloadManager.asset(for: track) {
+                self.play(asset: asset)
+            }
+            else {
+                track.prepare()
+                    .receive(on: RunLoop.main)
+                    .sink(receiveCompletion: { [weak self] completion in
+                        guard let self = self else { return }
+                        if case .failure = completion {
+                            self.preloadManager.markUnplayable(track)
+                            self.skipToNextPlayable(from: idx)
+                        }
+                    }, receiveValue: { [weak self] asset in
+                        guard let self = self else { return }
+                        self.play(asset: asset)
+                    }).store(in: &subscriptions)
+            }
         }
+        
+        triggerPreload(from: idx)
+    }
+    
+    private func play(asset: AVURLAsset) {
+        let item = AVPlayerItem(asset: asset)
+        
+        self.player.replaceCurrentItem(with: item)
+        self.player.play()
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.advanceForward), name: Notification.Name.AVPlayerItemDidPlayToEndTime, object: item)
+        
+        self.updateNowPlayingInfo()
+    }
+    
+    private func skipToNextPlayable(from index: Int) {
+        player.replaceCurrentItem(with: nil)
+        
+        // Find the next playable track within the queue
+        var nextIdx = index + 1
+        while nextIdx < queueOrder.count {
+            let track = queue[queueOrder[nextIdx]]
+            if !preloadManager.isUnplayable(track) {
+                resume(from: nextIdx)
+                return
+            }
+            nextIdx += 1
+        }
+        
+        // Wrap around if repeat is on
+        if repeatQueue {
+            var wrappedIdx = 0
+            while wrappedIdx < index {
+                let track = queue[queueOrder[wrappedIdx]]
+                if !preloadManager.isUnplayable(track) {
+                    resume(from: wrappedIdx)
+                    return
+                }
+                wrappedIdx += 1
+            }
+        }
+        
+        // No playable tracks found
+        queue = []
+        pause()
+    }
+    
+    private func triggerPreload(from index: Int) {
+        let nextIndex = index + 1
+        guard nextIndex < queue.count else { return }
+        preloadManager.evict(before: index, queue: queue, queueOrder: queueOrder)
+        preloadManager.preload(queue: queue, queueOrder: queueOrder, from: nextIndex)
     }
     
     func pause() {
@@ -177,6 +238,7 @@ class StreamPlayer: ObservableObject {
         }
         
         pause()
+        preloadManager.reset()
         queue = tracks
         
         // If we're in shuffle mode, we first have to unravel `idx`
@@ -228,6 +290,7 @@ class StreamPlayer: ObservableObject {
     func reset() {
         pause()
         player.replaceCurrentItem(with: nil)
+        preloadManager.reset()
         queue = []
         currentStreamIndex = nil
     }
@@ -240,6 +303,10 @@ class StreamPlayer: ObservableObject {
         }
         else {
             queue = queue + streams
+        }
+        
+        if let idx = currentStreamIndex {
+            triggerPreload(from: idx)
         }
     }
     

--- a/Nuage/Audio/StreamPlayer.swift
+++ b/Nuage/Audio/StreamPlayer.swift
@@ -184,8 +184,30 @@ class StreamPlayer: ObservableObject {
         self.player.play()
         
         NotificationCenter.default.addObserver(self, selector: #selector(self.advanceForward), name: Notification.Name.AVPlayerItemDidPlayToEndTime, object: item)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handlePlaybackError), name: Notification.Name.AVPlayerItemFailedToPlayToEndTime, object: item)
+        
+        // Observe item status to detect playback failures (e.g. licensing restrictions)
+        item.publisher(for: \.status)
+            .filter { $0 == .failed }
+            .first()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self = self,
+                      let idx = self.currentStreamIndex else { return }
+                let track = self.queue[self.queueOrder[idx]]
+                self.preloadManager.markUnplayable(track)
+                self.skipToNextPlayable(from: idx)
+            }
+            .store(in: &subscriptions)
         
         self.updateNowPlayingInfo()
+    }
+    
+    @objc private func handlePlaybackError() {
+        guard let idx = currentStreamIndex else { return }
+        let track = queue[queueOrder[idx]]
+        preloadManager.markUnplayable(track)
+        skipToNextPlayable(from: idx)
     }
     
     private func skipToNextPlayable(from index: Int) {

--- a/Nuage/Audio/StreamPlayer.swift
+++ b/Nuage/Audio/StreamPlayer.swift
@@ -246,9 +246,11 @@ class StreamPlayer: ObservableObject {
     
     private func triggerPreload(from index: Int) {
         let nextIndex = index + 1
-        guard nextIndex < queue.count else { return }
+        if nextIndex < queue.count {
+            preloadManager.preload(queue: queue, queueOrder: queueOrder, from: nextIndex)
+        }
+        preloadManager.preloadBackward(queue: queue, queueOrder: queueOrder, from: index)
         preloadManager.evict(before: index, queue: queue, queueOrder: queueOrder)
-        preloadManager.preload(queue: queue, queueOrder: queueOrder, from: nextIndex)
     }
     
     func pause() {

--- a/Nuage/Audio/StreamPlayer.swift
+++ b/Nuage/Audio/StreamPlayer.swift
@@ -43,6 +43,8 @@ class StreamPlayer: ObservableObject {
     
     @Published private(set) var currentStream: Track?
     
+    private var playbackHistory = [Int]()
+    
     @AppStorage("shuffleQueue") var shuffleQueue: Bool = false {
         didSet {
             // Here we have to unravel the index again
@@ -261,6 +263,7 @@ class StreamPlayer: ObservableObject {
         
         pause()
         preloadManager.reset()
+        playbackHistory.removeAll()
         queue = tracks
         
         // If we're in shuffle mode, we first have to unravel `idx`
@@ -272,6 +275,10 @@ class StreamPlayer: ObservableObject {
     @objc func advanceForward() {
         guard let idx = currentStreamIndex else { return }
         player.replaceCurrentItem(with: nil)
+        
+        // Record current track in history before moving forward
+        playbackHistory.append(idx)
+        
         if queue.count > idx + 1 {
             resume(from: idx + 1)
         }
@@ -289,8 +296,14 @@ class StreamPlayer: ObservableObject {
         
         if player.currentTime() < CMTime(value: 15, timescale: 1) {
             player.replaceCurrentItem(with: nil)
-            if idx > 0 {
-                resume(from: idx - 1)
+            
+            // Try playback history first (go back to what actually played)
+            if let previousIdx = popPreviousPlayable() {
+                resume(from: previousIdx)
+            }
+            // Fall back to scanning backward through the queue
+            else if idx > 0 {
+                skipToPreviousPlayable(from: idx)
             }
             else {
                 currentStreamIndex = nil
@@ -299,6 +312,32 @@ class StreamPlayer: ObservableObject {
         else {
             restartPlayback()
         }
+    }
+    
+    private func popPreviousPlayable() -> Int? {
+        while let previousIdx = playbackHistory.popLast() {
+            guard previousIdx < queueOrder.count else { continue }
+            let track = queue[queueOrder[previousIdx]]
+            if !preloadManager.isUnplayable(track) {
+                return previousIdx
+            }
+        }
+        return nil
+    }
+    
+    private func skipToPreviousPlayable(from index: Int) {
+        var prevIdx = index - 1
+        while prevIdx >= 0 {
+            let track = queue[queueOrder[prevIdx]]
+            if !preloadManager.isUnplayable(track) {
+                resume(from: prevIdx)
+                return
+            }
+            prevIdx -= 1
+        }
+        
+        // No playable track found behind us
+        currentStreamIndex = nil
     }
     
     func seekForward() {
@@ -313,6 +352,7 @@ class StreamPlayer: ObservableObject {
         pause()
         player.replaceCurrentItem(with: nil)
         preloadManager.reset()
+        playbackHistory.removeAll()
         queue = []
         currentStreamIndex = nil
     }


### PR DESCRIPTION
Hey guys, i started using this app today and like it very much!
I just had a small problem which was very annoying that i want to fix with the changes.
Some songs are not playable due to Premium status or geo-blocking. I added a preloading tool that checks if songs are playable and if not skips them. (It works for reverse-advancing too! :D )
A benefit of this is that if you have a bad internet connection songs start playing immediately.

Open to suggestions and critics :)

PS: A good portion of this was vibe-coded, i am not the most proficient with swift, but i tested it and it worked fine for me. Sometimes songs are stuck at second 1 but i think this has more to do with the API instead of my change? Maybe someone could look into it, i found nothing in the debug.